### PR TITLE
Fix #40: Separator has to be first

### DIFF
--- a/src/SumUp/Application/ApplicationConfiguration.php
+++ b/src/SumUp/Application/ApplicationConfiguration.php
@@ -313,7 +313,7 @@ class ApplicationConfiguration implements ApplicationConfigurationInterface
     protected function setGrantType($grantType)
     {
         if (!in_array($grantType, $this::GRANT_TYPES)) {
-            throw new SumUpConfigurationException('Invalid parameter for "grant_type". Allowed values are: ' . implode($this::GRANT_TYPES, ' | ') . '.');
+            throw new SumUpConfigurationException('Invalid parameter for "grant_type". Allowed values are: ' . implode(' | ', $this::GRANT_TYPES) . '.');
         }
         $this->grantType = $grantType;
     }


### PR DESCRIPTION
In php 8 the separator needs to be the first argument to implode() - in php 7 and earlier, it could be both first and last.