### PR TITLE
Replace pay_to_email with merchant_code in Checkout creation

### DIFF
--- a/src/SumUp/Services/Checkouts.php
+++ b/src/SumUp/Services/Checkouts.php
@@ -61,7 +61,7 @@ class Checkouts implements SumUpService
      * @throws \SumUp\Exceptions\SumUpAuthenticationException
      * @throws \SumUp\Exceptions\SumUpSDKException
      */
-    public function create($amount, $currency, $checkoutRef, $payToEmail, $description = '', $payFromEmail = null, $returnURL = null, $redirectURL = null)
+    public function create($amount, $currency, $checkoutRef, $merchantCode, $description = '', $payFromEmail = null, $returnURL = null, $redirectURL = null)
     {
         if (empty($amount) || !is_numeric($amount)) {
             throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('amount'));
@@ -72,16 +72,15 @@ class Checkouts implements SumUpService
         if (empty($checkoutRef)) {
             throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('checkout reference id'));
         }
-        if (empty($payToEmail)) {
-            throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('pay to email'));
-        }
+
         $payload = [
             'amount' => $amount,
             'currency' => $currency,
+            'merchant_code' => $merchantCode,
             'checkout_reference' => $checkoutRef,
-            'pay_to_email' => $payToEmail,
             'description' => $description
         ];
+
         if (isset($payFromEmail)) {
             $payload['pay_from_email'] = $payFromEmail;
         }


### PR DESCRIPTION
This PR addresses the issue of using `pay_to_email` instead of the recommended `merchant_code` in the Checkout creation process.

Changes made:
- Updated the `create` method in `src/SumUp/Services/Checkouts.php`:
   - Changed parameter `$payToEmail` to `$merchantCode`
   - Removed validation for `$payToEmail`
   - Updated payload to use `merchant_code` instead of `pay_to_email`


These changes align the SDK with the current API recommendations as per https://developer.sumup.com/api/checkouts/create#checkouts-create.

Note: This change may break backward compatibility for applications using the current version of the SDK. Consider incrementing the major version number and providing migration instructions in the changelog.

Please review and let me know if any further changes are needed.

https://github.com/sumup/sumup-ecom-php-sdk/issues/46