### PR TITLE
chore(checkouts): replace pay_to_email with the use of merchant_code

### DIFF
--- a/src/SumUp/Services/Checkouts.php
+++ b/src/SumUp/Services/Checkouts.php
@@ -72,11 +72,14 @@ class Checkouts implements SumUpService
         if (empty($checkoutRef)) {
             throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('checkout reference id'));
         }
+        if (empty($merchantCode)) {
+            throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('merchant code'));
+        }
 
         $payload = [
+            'merchant_code' => $merchantCode,
             'amount' => $amount,
             'currency' => $currency,
-            'merchant_code' => $merchantCode,
             'checkout_reference' => $checkoutRef,
             'description' => $description
         ];

--- a/src/SumUp/Services/Checkouts.php
+++ b/src/SumUp/Services/Checkouts.php
@@ -61,7 +61,7 @@ class Checkouts implements SumUpService
      * @throws \SumUp\Exceptions\SumUpAuthenticationException
      * @throws \SumUp\Exceptions\SumUpSDKException
      */
-    public function create($amount, $currency, $checkoutRef, $payToEmail, $description = '', $payFromEmail = null, $returnURL = null, $redirectURL = null)
+    public function create($amount, $currency, $checkoutRef, $merchantCode, $description = '', $payFromEmail = null, $returnURL = null, $redirectURL = null)
     {
         if (empty($amount) || !is_numeric($amount)) {
             throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('amount'));
@@ -72,16 +72,15 @@ class Checkouts implements SumUpService
         if (empty($checkoutRef)) {
             throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('checkout reference id'));
         }
-        if (empty($payToEmail)) {
-            throw new SumUpArgumentException(ExceptionMessages::getMissingParamMsg('pay to email'));
-        }
+
         $payload = [
             'amount' => $amount,
             'currency' => $currency,
+            'merchant_code' => $merchantCode,
             'checkout_reference' => $checkoutRef,
-            'pay_to_email' => $payToEmail,
             'description' => $description
         ];
+
         if (isset($payFromEmail)) {
             $payload['pay_from_email'] = $payFromEmail;
         }


### PR DESCRIPTION
Based on: https://github.com/sumup/sumup-ecom-php-sdk/pull/47, but brings back the param validation.

Closes: https://github.com/sumup/sumup-ecom-php-sdk/pull/47