### PR TITLE
chore: deprecate pay_to_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ try {
         'code'       => 'YOUR-AUTHORIZATION-CODE'
     ]);
     $checkoutService = $sumup->getCheckoutService();
-    $checkoutResponse = $checkoutService->create($amount, $currency, $checkoutRef, $payToEmail);
+    $merchantCode = 'YOUR-MERCHANT-CODE';
+    $checkoutResponse = $checkoutService->create($amount, $currency, $checkoutRef, $merchantCode);
     $checkoutId = $checkoutResponse->getBody()->id;
 //  pass the $chekoutId to the front-end to be processed
 } catch (\SumUp\Exceptions\SumUpAuthenticationException $e) {

--- a/docs/reference/Checkouts.md
+++ b/docs/reference/Checkouts.md
@@ -22,10 +22,11 @@ public function create(
     float  $amount,
     string $currency,
     string $checkoutRef,
-    string $payToEmail,
+    string $merchantCode,
     string $description = '',
     string $payFromEmail = null,
-    string $returnURL = null
+    string $returnURL = null,
+    string $redirectURL = null
 ): \SumUp\HttpClients\Response
 ```
 
@@ -43,7 +44,7 @@ Returns a `\SumUp\HttpClients\Response` or throws an exception.
 
 ### findByReferenceId()
 
-Searches for a checkout with particular `checkout_reference_id`.
+Searches for a checkout with particular `checkout_reference`.
 
 ```php
 public function findByReferenceId(string $referenceId): \SumUp\HttpClients\Response
@@ -53,7 +54,7 @@ Returns a `\SumUp\HttpClients\Response` or throws an exception.
 
 ### delete()
 
-Deactivates a checkout with particular `checkout_reference_id`;
+Deactivates a checkout with particular checkout `id`.
 
 ```php
 public function delete(string $checkoutId): \SumUp\HttpClients\Response

--- a/src/SumUp/Services/Checkouts.php
+++ b/src/SumUp/Services/Checkouts.php
@@ -47,7 +47,7 @@ class Checkouts implements SumUpService
      * @param float  $amount
      * @param string $currency
      * @param string $checkoutRef
-     * @param string $payToEmail
+     * @param string $merchantCode
      * @param string $description
      * @param null   $payFromEmail
      * @param null   $returnURL


### PR DESCRIPTION
As we are moving towards users possibly having access to multiple
merchant accounts, `pay_to_email` no longer makes sense.
This is a breaking change that removes it as an option from the SDK.
We already removed it from docs, APIs, and SDKs for other languages,
PHP was lacking behind.

Also fixes other parts of the documentation.

Fixes: https://github.com/sumup/sumup-ecom-php-sdk/issues/30
Fixes: https://github.com/sumup/sumup-ecom-php-sdk/issues/46
Fixes: https://github.com/sumup/sumup-ecom-php-sdk/issues/28
